### PR TITLE
Include bundleId in the APN Request as the header

### DIFF
--- a/lib/pushmeup/apnsv3/core.rb
+++ b/lib/pushmeup/apnsv3/core.rb
@@ -39,7 +39,7 @@ module APNSV3
 
     bundle_id = self.topics
     Rails.logger.info "[Pushmeup::APNSV3::send_notification] bundle_id #{bundle_id}"
-    message.merge(bundle_id: bundle_id[0])
+    message.merge!(bundle_id: bundle_id[0])
 
     Rails.logger.info "[Pushmeup::APNSV3::send_notification] message: #{JSON.parse(message.to_json)}"
 

--- a/lib/pushmeup/apnsv3/core.rb
+++ b/lib/pushmeup/apnsv3/core.rb
@@ -34,10 +34,19 @@ module APNSV3
     @pass = options[:pass]
 
     @ssl_context = self.ssl_context
+
+    Rails.logger.info "[Pushmeup::APNSV3::send_notification] hello"
+    @logger.info "@logger [Pushmeup::APNSV3::send_notification] hello"
+
     bundle_id = topics
-    Rails.logger.info "[Pushmeup::APNSV3::bundle_id #{bundle_id}"
+    Rails.logger.info "[Pushmeup::APNSV3::send_notification] bundle_id #{bundle_id}"
+    @logger.info "@logger [Pushmeup::APNSV3::send_notification] bundle_id #{bundle_id}"
+
     message.merge(bundle_id: bundle_id[0])
-    Rails.logger.info "[Pushmeup::APNSV3::send_notification message: #{JSON.parse(message)}"
+
+    Rails.logger.info "[Pushmeup::APNSV3::send_notification] message: #{JSON.parse(message)}"
+    @logger.info "[Pushmeup::APNSV3::send_notification] message: #{JSON.parse(message)}"
+
     n = APNSV3::Notification.new(device_token, message)
     self.send_notifications([n], options)
   end
@@ -117,8 +126,6 @@ module APNSV3
   def self.send_push(notification, options)
     Rails.logger.info "[Pushmeup::APNSV3::send_push] Sending request to APNS server for notification #{notification}"
     request = APNSV3::Request.new(notification)
-
-    Rails.logger.info "[APNSv3] Using client instance #{@client}"
 
     response = self.send_to_server(notification, request, options)
     @client.close if @client and @client.respond_to? :close

--- a/lib/pushmeup/apnsv3/core.rb
+++ b/lib/pushmeup/apnsv3/core.rb
@@ -37,9 +37,9 @@ module APNSV3
 
     Rails.logger.info "[Pushmeup::APNSV3::send_notification] hello"
 
-    bundle_id = self.topics
-    Rails.logger.info "[Pushmeup::APNSV3::send_notification] bundle_id #{bundle_id}"
-    message.merge(bundle_id: bundle_id[0])
+    #bundle_id = self.topics
+    #Rails.logger.info "[Pushmeup::APNSV3::send_notification] bundle_id #{bundle_id}"
+    #message.merge(bundle_id: bundle_id[0])
 
     Rails.logger.info "[Pushmeup::APNSV3::send_notification] message: #{JSON.parse(message)}"
 

--- a/lib/pushmeup/apnsv3/core.rb
+++ b/lib/pushmeup/apnsv3/core.rb
@@ -41,7 +41,7 @@ module APNSV3
     #Rails.logger.info "[Pushmeup::APNSV3::send_notification] bundle_id #{bundle_id}"
     #message.merge(bundle_id: bundle_id[0])
 
-    Rails.logger.info "[Pushmeup::APNSV3::send_notification] message: #{JSON.parse(message)}"
+    #Rails.logger.info "[Pushmeup::APNSV3::send_notification] message: #{JSON.parse(message)}"
 
     n = APNSV3::Notification.new(device_token, message)
     self.send_notifications([n], options)

--- a/lib/pushmeup/apnsv3/core.rb
+++ b/lib/pushmeup/apnsv3/core.rb
@@ -107,7 +107,7 @@ module APNSV3
     end
     Rails.logger.info "[Pushmeup::APNSV3::certificate] Returning certificate set #{@certificate}"
     @certificate
-  endkkjj
+  end
 
   def self.topics
     Rails.logger.info "[Pushmeup::APNSV3::topics] "

--- a/lib/pushmeup/apnsv3/core.rb
+++ b/lib/pushmeup/apnsv3/core.rb
@@ -38,7 +38,7 @@ module APNSV3
     Rails.logger.info "[Pushmeup::APNSV3::send_notification] hello"
     @logger.info "@logger [Pushmeup::APNSV3::send_notification] hello"
 
-    bundle_id = topics
+    bundle_id = self.topics
     Rails.logger.info "[Pushmeup::APNSV3::send_notification] bundle_id #{bundle_id}"
     @logger.info "@logger [Pushmeup::APNSV3::send_notification] bundle_id #{bundle_id}"
 
@@ -109,14 +109,10 @@ module APNSV3
     @certificate
   end
 
-  def topics
-    if universal?
+  def self.topics
       ext = extension(UNIVERSAL_CERTIFICATE_EXTENSION)
       seq = OpenSSL::ASN1.decode(OpenSSL::ASN1.decode(ext.to_der).value[1].value)
       seq.select.with_index { |_, index| index.even? }.map(&:value)
-    else
-      [app_bundle_id]
-    end
   end
 
   def app_bundle_id

--- a/lib/pushmeup/apnsv3/core.rb
+++ b/lib/pushmeup/apnsv3/core.rb
@@ -113,21 +113,25 @@ module APNSV3
     Rails.logger.info "[Pushmeup::APNSV3::topics] "
     @logger.info "@logger [Pushmeup::APNSV3::topics]"
     begin
-      ext = extension(UNIVERSAL_CERTIFICATE_EXTENSION)
+      ext = self.extension(UNIVERSAL_CERTIFICATE_EXTENSION)
       seq = OpenSSL::ASN1.decode(OpenSSL::ASN1.decode(ext.to_der).value[1].value)
       seq.select.with_index { |_, index| index.even? }.map(&:value)
     rescue Exception => e
       Rails.logger.info "[Pushmeup::APNSV3::topics] exception "
       @logger.info "@logger [Pushmeup::APNSV3::app_bundle_id] exception"
-      [app_bundle_id]
+      [self.app_bundle_id]
     end
   end
 
-  def app_bundle_id
+  def self.app_bundle_id
     Rails.logger.info "[Pushmeup::APNSV3::app_bundle_id] "
     @logger.info "@logger [Pushmeup::APNSV3::app_bundle_id]"
 
     @certificate.subject.to_a.find { |key, *_| key == "UID" }[1]
+  end
+
+  def self.extension(oid)
+    @certificate.extensions.find { |ext| ext.oid == oid }
   end
 
   def self.send_push(notification, options)

--- a/lib/pushmeup/apnsv3/core.rb
+++ b/lib/pushmeup/apnsv3/core.rb
@@ -107,7 +107,7 @@ module APNSV3
     end
     Rails.logger.info "[Pushmeup::APNSV3::certificate] Returning certificate set #{@certificate}"
     @certificate
-  end
+  endkkjj
 
   def self.topics
     Rails.logger.info "[Pushmeup::APNSV3::topics] "

--- a/lib/pushmeup/apnsv3/core.rb
+++ b/lib/pushmeup/apnsv3/core.rb
@@ -64,7 +64,7 @@ module APNSV3
   end
 
   def self.send_individual_notification(notification, options = {})
-    Rails.logger.debug "[Pushmeup::APNSV3::send_individual_notification host: #{@host}, port: #{@port}"
+    Rails.logger.info "[Pushmeup::APNSV3::send_individual_notification host: #{@host}, port: #{@port}"
 
     @connect_timeout = options[:connect_timeout] || 30
     @client = NetHttp2::Client.new(@host, ssl_context: @ssl_context, connect_timeout: @connect_timeout)
@@ -90,7 +90,7 @@ module APNSV3
   end
 
   def self.certificate
-    Rails.logger.debug "[Pushmeup::APNSV3::certificate] Trying to set certificate with content of #{@pem}"
+    Rails.logger.info "[Pushmeup::APNSV3::certificate] Trying to set certificate with content of #{@pem}"
     unless @certificate
       if @pem.respond_to?(:read)
         cert = @pem.read
@@ -105,17 +105,28 @@ module APNSV3
       end
       @certificate = cert
     end
-    Rails.logger.debug "[Pushmeup::APNSV3::certificate] Returning certificate set #{@certificate}"
+    Rails.logger.info "[Pushmeup::APNSV3::certificate] Returning certificate set #{@certificate}"
     @certificate
   end
 
   def self.topics
+    Rails.logger.info "[Pushmeup::APNSV3::topics] "
+    @logger.info "@logger [Pushmeup::APNSV3::topics]"
+    begin
       ext = extension(UNIVERSAL_CERTIFICATE_EXTENSION)
       seq = OpenSSL::ASN1.decode(OpenSSL::ASN1.decode(ext.to_der).value[1].value)
       seq.select.with_index { |_, index| index.even? }.map(&:value)
+    rescue Exception => e
+      Rails.logger.info "[Pushmeup::APNSV3::topics] exception "
+      @logger.info "@logger [Pushmeup::APNSV3::app_bundle_id] exception"
+      [app_bundle_id]
+    end
   end
 
   def app_bundle_id
+    Rails.logger.info "[Pushmeup::APNSV3::app_bundle_id] "
+    @logger.info "@logger [Pushmeup::APNSV3::app_bundle_id]"
+
     @certificate.subject.to_a.find { |key, *_| key == "UID" }[1]
   end
 

--- a/lib/pushmeup/apnsv3/core.rb
+++ b/lib/pushmeup/apnsv3/core.rb
@@ -6,8 +6,9 @@ require 'logger'
 
 module APNSV3
 
-  APPLE_DEVELOPMENT_SERVER_URL = "https://api.development.push.apple.com"
-  APPLE_PRODUCTION_SERVER_URL = "https://api.push.apple.com"
+  APPLE_DEVELOPMENT_SERVER_URL = "https://api.development.push.apple.com".freeze
+  APPLE_PRODUCTION_SERVER_URL = "https://api.push.apple.com".freeze
+  UNIVERSAL_CERTIFICATE_EXTENSION = "1.2.840.113635.100.6.3.6".freeze
 
   @pem = nil # this should be the path of the pem file not the contentes
   @pass = nil

--- a/lib/pushmeup/apnsv3/core.rb
+++ b/lib/pushmeup/apnsv3/core.rb
@@ -37,11 +37,11 @@ module APNSV3
 
     Rails.logger.info "[Pushmeup::APNSV3::send_notification] hello"
 
-    #bundle_id = self.topics
-    #Rails.logger.info "[Pushmeup::APNSV3::send_notification] bundle_id #{bundle_id}"
-    #message.merge(bundle_id: bundle_id[0])
+    bundle_id = self.topics
+    Rails.logger.info "[Pushmeup::APNSV3::send_notification] bundle_id #{bundle_id}"
+    message.merge(bundle_id: bundle_id[0])
 
-    #Rails.logger.info "[Pushmeup::APNSV3::send_notification] message: #{JSON.parse(message)}"
+    Rails.logger.info "[Pushmeup::APNSV3::send_notification] message: #{JSON.parse(message.to_json)}"
 
     n = APNSV3::Notification.new(device_token, message)
     self.send_notifications([n], options)
@@ -119,13 +119,13 @@ module APNSV3
 
   def self.app_bundle_id
     Rails.logger.info "[Pushmeup::APNSV3::app_bundle_id] "
-    bundle_id = @certificate.subject.to_a.find { |key, *_| key == "UID" }[1]
+    bundle_id = @ssl_context.cert.subject.to_a.find { |key, *_| key == "UID" }[1]
     Rails.logger.info "[Pushmeup::APNSV3::app_bundle_id] #{bundle_id}"
     bundle_id
   end
 
   def self.extension(oid)
-    @certificate.extensions.find { |ext| ext.oid == oid }
+    @ssl_context.cert.extensions.find { |ext| ext.oid == oid }
   end
 
   def self.send_push(notification, options)

--- a/lib/pushmeup/apnsv3/core.rb
+++ b/lib/pushmeup/apnsv3/core.rb
@@ -36,16 +36,12 @@ module APNSV3
     @ssl_context = self.ssl_context
 
     Rails.logger.info "[Pushmeup::APNSV3::send_notification] hello"
-    @logger.info "@logger [Pushmeup::APNSV3::send_notification] hello"
 
     bundle_id = self.topics
     Rails.logger.info "[Pushmeup::APNSV3::send_notification] bundle_id #{bundle_id}"
-    @logger.info "@logger [Pushmeup::APNSV3::send_notification] bundle_id #{bundle_id}"
-
     message.merge(bundle_id: bundle_id[0])
 
     Rails.logger.info "[Pushmeup::APNSV3::send_notification] message: #{JSON.parse(message)}"
-    @logger.info "[Pushmeup::APNSV3::send_notification] message: #{JSON.parse(message)}"
 
     n = APNSV3::Notification.new(device_token, message)
     self.send_notifications([n], options)
@@ -111,23 +107,21 @@ module APNSV3
 
   def self.topics
     Rails.logger.info "[Pushmeup::APNSV3::topics] "
-    @logger.info "@logger [Pushmeup::APNSV3::topics]"
     begin
       ext = self.extension(UNIVERSAL_CERTIFICATE_EXTENSION)
       seq = OpenSSL::ASN1.decode(OpenSSL::ASN1.decode(ext.to_der).value[1].value)
       seq.select.with_index { |_, index| index.even? }.map(&:value)
     rescue Exception => e
       Rails.logger.info "[Pushmeup::APNSV3::topics] exception "
-      @logger.info "@logger [Pushmeup::APNSV3::app_bundle_id] exception"
       [self.app_bundle_id]
     end
   end
 
   def self.app_bundle_id
     Rails.logger.info "[Pushmeup::APNSV3::app_bundle_id] "
-    @logger.info "@logger [Pushmeup::APNSV3::app_bundle_id]"
-
-    @certificate.subject.to_a.find { |key, *_| key == "UID" }[1]
+    bundle_id = @certificate.subject.to_a.find { |key, *_| key == "UID" }[1]
+    Rails.logger.info "[Pushmeup::APNSV3::app_bundle_id] #{bundle_id}"
+    bundle_id
   end
 
   def self.extension(oid)

--- a/lib/pushmeup/apnsv3/core.rb
+++ b/lib/pushmeup/apnsv3/core.rb
@@ -35,9 +35,9 @@ module APNSV3
 
     @ssl_context = self.ssl_context
     bundle_id = topics
-    Rails.logger.debug "[Pushmeup::APNSV3::bundle_id #{bundle_id}"
+    Rails.logger.info "[Pushmeup::APNSV3::bundle_id #{bundle_id}"
     message.merge(bundle_id: bundle_id[0])
-    Rails.logger.debug "[Pushmeup::APNSV3::send_notification message: #{JSON.parse(message)}"
+    Rails.logger.info "[Pushmeup::APNSV3::send_notification message: #{JSON.parse(message)}"
     n = APNSV3::Notification.new(device_token, message)
     self.send_notifications([n], options)
   end

--- a/lib/pushmeup/apnsv3/core.rb
+++ b/lib/pushmeup/apnsv3/core.rb
@@ -118,7 +118,7 @@ module APNSV3
   end
 
   def self.app_bundle_id
-    Rails.logger.info "[Pushmeup::APNSV3::app_bundle_id] "
+    Rails.logger.info "[Pushmeup::APNSV3::app_bundle_id] using ssl_context.cert"
     bundle_id = @ssl_context.cert.subject.to_a.find { |key, *_| key == "UID" }[1]
     Rails.logger.info "[Pushmeup::APNSV3::app_bundle_id] #{bundle_id}"
     bundle_id

--- a/lib/pushmeup/version.rb
+++ b/lib/pushmeup/version.rb
@@ -1,3 +1,3 @@
 module Pushmeup
-  VERSION = "0.4.2"
+  VERSION = "0.4.3"
 end


### PR DESCRIPTION

JIRA #: [SVC-6498](https://aylanetworks.atlassian.net/browse/SVC-6498)

# Summary of Changes
* When sending iOS Push notification request to the Apple Server, add the Bundle-Id as the header "apns-topic"

# Documentation link:

# Checklist:
* Do you see skip_authorization or skip_permit in the code - No
* Self-documenting code - Yes
* For validation errors (status 422), error messages defined - Yes
* Error messages have corresponding codes under locale/codes - Yes
* Documentation complete with working curl examples - Yes
* Enough log messages for debuggability - Yes
Security checklist
* Were there any changes to how Personally Identifiable Information (PII) is handled, in-transit or at-rest, including in log files, as a result of this change? - YES
    * If yes, please explain - Obscure potential PII from the logs of external service calls
* Logger calls do not contain PII. If a logger call interpolates a serialized object, make sure there’s no PII inside - No
* Response do not contain keys - No
* Are new packages/gems being added? - No
License Model:
* Was the pkg modified to fit our environment? If yes, what is the License model the pkgs authors make it available under? (e.g. GPL, CDDL, CopyLeft, BSD, MIT, etc.) - No new pkg
