### PR TITLE
0.4.4 release. Remove of pem information disclosure logs (SVC-7097)

### DIFF
--- a/lib/pushmeup/apnsv3/core.rb
+++ b/lib/pushmeup/apnsv3/core.rb
@@ -79,7 +79,6 @@ module APNSV3
   end
 
   def self.certificate
-    Rails.logger.info "[Pushmeup::APNSV3::certificate] Trying to set certificate with content of #{@pem}"
     unless @certificate
       if @pem.respond_to?(:read)
         cert = @pem.read
@@ -88,7 +87,7 @@ module APNSV3
         begin
           cert = File.read(@pem)
         rescue SystemCallError => e
-          Rails.logger.info "[Pushmeup::APNSV3::certificate] Does not understand read and its not a path to a file or directory, setting as plain string. Content: #{@cert_pem}"
+          Rails.logger.info "[Pushmeup::APNSV3::certificate] Does not understand read and its not a path to a file or directory, setting as plain string."
           cert = @pem
         end
       end

--- a/lib/pushmeup/version.rb
+++ b/lib/pushmeup/version.rb
@@ -1,3 +1,3 @@
 module Pushmeup
-  VERSION = '0.4.3'
+  VERSION = '0.4.4'
 end


### PR DESCRIPTION
## JIRA ID

## Summary of Changes
- Remove logs that show pem and pem_cert on the logs for APNSv3
- New version release 0.4.4

## Documentation link 

## License Model
N/A

## Checklist
- Do you see skip_authorization or skip_permit in the code, there must be justification for it ✔
- Self-documenting code ✔
- For validation errors (status 422), error messages defined ✔
- Error messages have corresponding codes under locale/codes ✔
- Documentation complete with working curl examples ✔
- Enough log messages for debuggability ✔

## Security checklist
- No passwords in logs ✔
- Response do not contain keys ✔
- Are new packages/gems being added? If so, what is the need for those packages/gems? ✔