### PR TITLE
passing FCM api_key in send_notifications method

### DIFF
--- a/lib/pushmeup/fcm/core.rb
+++ b/lib/pushmeup/fcm/core.rb
@@ -26,11 +26,11 @@ module FCM
 
   def self.send_notifications(registration_ids, data={}, options = {})
     notification = Notification.new(registration_ids, data, options)
-    self.prepare_and_send(notification)
+    self.prepare_and_send(notification, options)
   end
 
 
-  def self.prepare_and_send(notification)
+  def self.prepare_and_send(notification, options = {})
     registration_ids = notification.registration_ids
 
     Rails.logger.info "[Pushmeup::FCM::prepare_and_send] registartion_ids #{registration_ids}"
@@ -38,11 +38,11 @@ module FCM
     post_body = build_post_body(registration_ids, notification.get_options)
 
     Rails.logger.info "[Pushmeup::FCM::prepare_and_send] request body json #{post_body.to_json}"
-
+    api_key = options[:api_key] || @api_key
     params = {
         body: post_body.to_json,
         headers: {
-            'Authorization' => "key=#{@api_key}",
+            'Authorization' => "key=#{api_key}",
             'Content-Type' => 'application/json'
         }
     }

--- a/lib/pushmeup/version.rb
+++ b/lib/pushmeup/version.rb
@@ -1,3 +1,3 @@
 module Pushmeup
-  VERSION = '0.4.5'
+  VERSION = '0.4.6'
 end


### PR DESCRIPTION
# SVC-10224

### Change Summary
- Fetching FCM api_key from send notification method
- updating version

### Checklist:
Do you see skip_authorization or skip_permit in the code, there must be justification for it - 👍
Self-documenting code - 👍
For validation errors (status 422), error messages defined - 👍
Error messages have corresponding codes under locale/codes - 👍
Enough log messages for debuggability - 👍

### Security checklist:
Were there any changes to how Personally Identifiable Information (PII) is handled, in-transit or at-rest, including in log files, as a result of this change? - 👎
Logger calls do not contain PII. If a logger call interpolates a serialized object, make sure there’s no PII inside - 👍
No passwords in logs - 👍
Response do not contains keys - 👍
Are new packages/gems being added? - 👎

### License Model:
Was the pkg modified to fit our environment? If yes, what is the License model the pkgs authors make it available under? (e.g. GPL, CDDL, CopyLeft, BSD, MIT, etc.) - 👍