### PR TITLE
adding priority option for fcm notifications.

### DIFF
--- a/lib/pushmeup/fcm/notification.rb
+++ b/lib/pushmeup/fcm/notification.rb
@@ -1,7 +1,7 @@
 module FCM
 
   class Notification
-    attr_accessor :registration_ids, :data, :collapse_key, :time_to_live, :delay_while_idle, :identity, :condition
+    attr_accessor :registration_ids, :data, :collapse_key, :time_to_live, :delay_while_idle, :identity, :condition, :priority
 
     def initialize(registration_ids, data, options = {})
       self.registration_ids = registration_ids
@@ -12,6 +12,7 @@ module FCM
       @delay_while_idle = options[:delay_while_idle]
       @identity = options[:identity]
       @condition = options[:conditions]
+      @priority = options[:priority] || false
     end
 
     def registration_ids=(registration_ids)
@@ -36,6 +37,10 @@ module FCM
       @delay_while_idle = (delay_while_idle == true || delay_while_idle == :true)
     end
 
+    def priority=(delay_while_idle)
+      @priority = (priority == true || priority == :true)
+    end
+
     def time_to_live=(time_to_live)
       if time_to_live.is_a?(Integer)
         @time_to_live = time_to_live
@@ -55,6 +60,10 @@ module FCM
       options[:collapse_key] = self.collapse_key if self.collapse_key
       options[:identity] = self.identity if self.identity
       options[:data] = self.data if self.data_present?
+      if self.priority
+        options[:android] = { priority: "high" }
+        options[:priority] = "high"
+      end
       options
     end
 

--- a/spec/lib/fcm_spec.rb
+++ b/spec/lib/fcm_spec.rb
@@ -97,6 +97,20 @@ describe 'Pushmeup FCM' do
           FCM.send_notification(registration_ids, {score: '345', time: '12:20'}, {})
           stub_with_data.should have_been_made.times(1)
         end
+
+        it "should set priority high in the options" do 
+          notification = FCM::Notification.new(registration_ids, {score: '345', time: '12:20'}, {priority: true})
+          options = notification.get_options
+          options[:android][:priority].should eq("high")
+          options[:priority].should eq("high")
+        end
+
+        it "should not set priority high in the options if no priority is given" do 
+          notification = FCM::Notification.new(registration_ids, {score: '345', time: '12:20'}, {})
+          options = notification.get_options
+          options[:android].should be_nil
+          options[:priority].should be_nil
+        end
       end
 
       context 'when send_notification fails' do


### PR DESCRIPTION
### [``` SVC-14504 ```](https://aylanetworks.atlassian.net/browse/SVC-14504)
### Change Summary
- Added option for setting Priority
- Added priority for the fcm notification payload.
### Checklist:
Do you see skip_authorization or skip_permit in the code, there must be justification for it - 👍
Self-documenting code - 👍
For validation errors (status 422), error messages defined - 👍
Error messages have corresponding codes under locale/codes - 👍
Enough log messages for debuggability - 👍
### Security checklist:
Were there any changes to how Personally Identifiable Information (PII) is handled,
in-transit or at-rest, including in log files, as a result of this change? - 👍
Logger calls do not contain PII. If a logger call interpolates a serialized object, make sure there’s no PII inside - 👍
No passwords in logs - 👍
The response does not contain keys - 👍
Are new packages/gems being added? - 👍
### License Model:
Was the pkg modified to fit our environment? If yes, what is the License model the pkgs authors make it available under? (e.g. GPL, CDDL, CopyLeft, BSD, MIT, etc.) - 👍